### PR TITLE
Cloud sandbox includes .NET Core 3.1

### DIFF
--- a/ManageStorageTiers/ManageStorageTiers/ManageStorageTiers.csproj
+++ b/ManageStorageTiers/ManageStorageTiers/ManageStorageTiers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I was following the "Optimize storage performance and costs using Blob storage tiers" (https://docs.microsoft.com/en-us/learn/modules/optimize-archive-costs-blob-storage/) lesson and encountered an error with the sample code https://docs.microsoft.com/en-us/learn/modules/optimize-archive-costs-blob-storage/6-exercise-manage-tiered-storage-using-asp.net-core-apps. 

```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.1.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.1.0&arch=x64&rid=cbld.10-x64
```

Cloud sandbox:
```
dotnet --list-sdks
3.1.403 [/usr/share/dotnet/sdk]
```
